### PR TITLE
Support batching

### DIFF
--- a/src/extractors/base-extractor.ts
+++ b/src/extractors/base-extractor.ts
@@ -1,13 +1,31 @@
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import * as os from 'os';
-import { ExtractorConfig, ExtractionResult } from '../types/node-description';
+import {
+  CompleteNodeDescription,
+  ExtractorConfig,
+  ExtractionResult,
+} from '../types/node-description';
 
-export abstract class BaseExtractor<T> {
+// Type definitions for better type safety
+interface NodeModule {
+  default?: any;
+  [key: string]: any;
+}
+
+interface NodeInstance {
+  description: Partial<CompleteNodeDescription>;
+  methods?: {
+    loadOptions?: Record<string, Function>;
+    [key: string]: any;
+  };
+}
+
+export abstract class BaseExtractor<TItems, TConfig> {
   protected tempDir: string;
   protected outputDir: string;
   protected verbose: boolean;
-  protected extractedItems: T[] = [];
+  protected extractedItems!: TItems;
 
   constructor(config?: ExtractorConfig) {
     this.tempDir = config?.tempDir || path.join(os.tmpdir(), 'extractor-' + Date.now());
@@ -24,10 +42,10 @@ export abstract class BaseExtractor<T> {
     }
   }
 
-  async extract(packageName: string): Promise<T[]> {
+  async extract(config: TConfig): Promise<TItems> {
     try {
-      await this.beforeExtract(packageName);
-      const results = await this.extractInternal(packageName);
+      await this.beforeExtract(config);
+      const results = await this.extractInternal(config);
       this.extractedItems = results;
       await this.afterExtract();
       return results;
@@ -37,9 +55,9 @@ export abstract class BaseExtractor<T> {
     }
   }
 
-  protected abstract extractInternal(packageName: string): Promise<T[]>;
+  protected abstract extractInternal(config: TConfig): Promise<TItems>;
 
-  protected async beforeExtract(packageName: string): Promise<void> {
+  protected async beforeExtract(config: TConfig): Promise<void> {
     // May need this in the future
   }
 
@@ -51,11 +69,22 @@ export abstract class BaseExtractor<T> {
    * Save results with metadata
    */
   async saveResults(filename: string, format: string): Promise<void> {
-    const data: ExtractionResult<T> = {
+    const totalNodes = Array.isArray(this.extractedItems)
+      ? this.extractedItems.length
+      : typeof this.extractedItems === 'object' && this.extractedItems !== null
+        ? Object.values(this.extractedItems).reduce(
+            (sum: number, nodes: any) => sum + (Array.isArray(nodes) ? nodes.length : 0),
+            0
+          )
+        : 0;
+
+    const data: ExtractionResult<TItems> = {
       extractedAt: new Date().toISOString(),
-      totalNodes: this.extractedItems.length,
+      totalNodes,
       format,
-      nodes: this.extractedItems,
+      nodes: (Array.isArray(this.extractedItems)
+        ? this.extractedItems
+        : [this.extractedItems]) as any,
     };
 
     const filePath = path.join(this.outputDir, filename);
@@ -80,7 +109,255 @@ export abstract class BaseExtractor<T> {
   /**
    * Get extracted items
    */
-  getItems(): T[] {
+  getItems(): TItems {
     return this.extractedItems;
+  }
+
+  /**
+   * Resolve node class from module exports
+   */
+  protected resolveNodeClass(nodeModule: any): any {
+    if (nodeModule.default && typeof nodeModule.default === 'function') {
+      return nodeModule.default;
+    }
+
+    // Try any function export
+    for (const [key, value] of Object.entries(nodeModule)) {
+      if (typeof value === 'function' && key !== 'default') {
+        return value;
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Process node icons and return icon information
+   */
+  protected processNodeIcons(
+    description: any,
+    packageName: string,
+    filePath: string,
+    packagePath: string
+  ): { icon?: string; iconUrl?: string; iconLightUrl?: string; iconDarkUrl?: string } {
+    const result: { icon?: string; iconUrl?: string; iconLightUrl?: string; iconDarkUrl?: string } =
+      {};
+
+    if (description.icon) {
+      if (typeof description.icon === 'string') {
+        if (description.icon.startsWith('fa:')) {
+          result.icon = description.icon;
+        } else {
+          const iconPath = description.icon.startsWith('file:')
+            ? description.icon.replace('file:', '')
+            : description.icon;
+          result.iconUrl = this.generateIconUrl(iconPath, packageName, filePath, packagePath);
+        }
+      } else if (
+        typeof description.icon === 'object' &&
+        (description.icon.light || description.icon.dark)
+      ) {
+        if (description.icon.light) {
+          const iconLightPath = description.icon.light.startsWith('file:')
+            ? description.icon.light.replace('file:', '')
+            : description.icon.light;
+          result.iconLightUrl = this.generateIconUrl(
+            iconLightPath,
+            packageName,
+            filePath,
+            packagePath
+          );
+        }
+        if (description.icon.dark) {
+          const iconDarkPath = description.icon.dark.startsWith('file:')
+            ? description.icon.dark.replace('file:', '')
+            : description.icon.dark;
+          result.iconDarkUrl = this.generateIconUrl(
+            iconDarkPath,
+            packageName,
+            filePath,
+            packagePath
+          );
+          // If both light and dark are present, prefer dark for iconUrl
+          result.iconUrl = result.iconDarkUrl;
+        } else if (result.iconLightUrl) {
+          // If only light is present, use it for iconUrl
+          result.iconUrl = result.iconLightUrl;
+        }
+      }
+    }
+
+    if (description.iconUrl) {
+      result.iconUrl = this.generateIconUrl(
+        description.iconUrl,
+        packageName,
+        filePath,
+        packagePath
+      );
+    }
+
+    return result;
+  }
+
+  /**
+   * Generate node name from original name and package name
+   */
+  protected generateNodeName(originalName: string, packageName: string): string {
+    const cleanPackageName = packageName.replace(/^@[^/]+\//, '').replace(/^n8n-nodes-/, '');
+    return `n8n-nodes-${cleanPackageName}.${originalName}`;
+  }
+
+  /**
+   * Generate icon URL from icon path
+   */
+  protected generateIconUrl(
+    iconPath: string,
+    packageName: string,
+    nodePath: string,
+    packagePath: string
+  ): string {
+    const cleanPackageName = packageName.replace(/^@[^/]+\//, '');
+    const nodeDir = path.dirname(nodePath);
+
+    // Remove any leading "file:" prefix
+    let normalizedIconPath = iconPath.startsWith('file:')
+      ? iconPath.replace(/^file:/, '')
+      : iconPath;
+
+    // Resolve path based on different patterns
+    let resolvedPath = normalizedIconPath;
+
+    if (normalizedIconPath.startsWith('/')) {
+      // Absolute path within package
+      resolvedPath = normalizedIconPath.substring(1);
+    } else if (
+      !normalizedIconPath.includes('/') ||
+      normalizedIconPath.startsWith('./') ||
+      normalizedIconPath.startsWith('../')
+    ) {
+      // Relative path or just filename
+      const absolutePath = path.resolve(nodeDir, normalizedIconPath);
+      resolvedPath = path.relative(packagePath, absolutePath).replace(/\\/g, '/');
+    }
+
+    return `icons/${cleanPackageName}/${resolvedPath}`;
+  }
+
+  /**
+   * Safely load a node module with timeout
+   */
+  protected async loadNodeModule(filePath: string, timeoutMs: number = 10000): Promise<NodeModule> {
+    return new Promise((resolve, reject) => {
+      const timeoutId = setTimeout(() => {
+        reject(new Error(`Module load timeout: ${filePath}`));
+      }, timeoutMs);
+
+      try {
+        const resolvedPath = require.resolve(filePath);
+        delete require.cache[resolvedPath];
+        const module = require(filePath);
+        clearTimeout(timeoutId);
+        resolve(module);
+      } catch (error) {
+        clearTimeout(timeoutId);
+        reject(error);
+      }
+    });
+  }
+
+  /**
+   * Extract complete node description from a file
+   */
+  protected async extractCompleteNode(
+    filePath: string,
+    packageName: string,
+    packagePath: string,
+    nodeModulesPath: string
+  ): Promise<CompleteNodeDescription | null> {
+    try {
+      this.log(`[${packageName}] 🔧 Extracting description from: ${path.basename(filePath)}`);
+
+      // Setup module resolution
+      const originalPaths = module.paths.slice();
+
+      if (!module.paths.includes(nodeModulesPath)) {
+        module.paths.unshift(nodeModulesPath);
+      }
+
+      try {
+        // Load the module with timeout safety
+        const nodeModule = await this.loadNodeModule(filePath);
+
+        // Use the extracted method to get the node class
+        const NodeClass = this.resolveNodeClass(nodeModule);
+
+        if (!NodeClass || typeof NodeClass !== 'function') {
+          this.log(`❌ No valid NodeClass found in ${path.basename(filePath)}`);
+          return null;
+        }
+
+        // Create instance and get description
+        const nodeInstance = new NodeClass();
+        const description = nodeInstance.description;
+
+        if (!description || !description.name) {
+          this.log(`❌ No valid description in ${path.basename(filePath)}`);
+          return null;
+        }
+
+        console.log(`✅ Extracted description for: ${description.displayName}`);
+
+        // Return the COMPLETE description object
+        const completeDescription: CompleteNodeDescription = {
+          ...description,
+          displayName: description.displayName,
+          name: this.generateNodeName(description.name, packageName),
+          group: description.group || [],
+          version: description.version,
+          description: description.description || '',
+          defaults: description.defaults || {},
+          inputs: description.inputs || ['main'],
+          outputs: description.outputs || ['main'],
+          properties: description.properties || [],
+        };
+
+        // Add load options methods if available
+        if (nodeInstance.methods?.loadOptions) {
+          completeDescription.__loadOptionsMethods = Object.keys(nodeInstance.methods.loadOptions);
+        }
+
+        // Process icons using the extracted method
+        const iconInfo = this.processNodeIcons(description, packageName, filePath, packagePath);
+
+        if (iconInfo.icon) {
+          completeDescription.icon = iconInfo.icon;
+          // If we're using a Font Awesome icon, remove any iconUrl
+          if (iconInfo.icon.startsWith('fa:')) {
+            delete completeDescription.iconUrl;
+          }
+        }
+
+        if (iconInfo.iconUrl) {
+          completeDescription.iconUrl = iconInfo.iconUrl;
+        }
+
+        if (iconInfo.iconLightUrl) {
+          completeDescription.iconUrl = iconInfo.iconLightUrl;
+        }
+        if (iconInfo.iconDarkUrl) {
+          completeDescription.iconUrl = iconInfo.iconDarkUrl;
+        }
+
+        return completeDescription;
+      } finally {
+        // Restore paths
+        module.paths.splice(0, module.paths.length, ...originalPaths);
+      }
+    } catch (error) {
+      this.log(
+        `❌ Extraction error for ${path.basename(filePath)}: ${error instanceof Error ? error.message : String(error)}`
+      );
+      return null;
+    }
   }
 }

--- a/src/extractors/base-extractor.ts
+++ b/src/extractors/base-extractor.ts
@@ -7,7 +7,6 @@ import {
   ExtractionResult,
 } from '../types/node-description';
 
-// Type definitions for better type safety
 interface NodeModule {
   default?: any;
   [key: string]: any;

--- a/src/extractors/multiple-node-extractor.ts
+++ b/src/extractors/multiple-node-extractor.ts
@@ -27,10 +27,8 @@ export class MultipleNodeExtractor extends BaseExtractor<
     );
 
     try {
-      // Create temp directory
       await fs.mkdir(this.tempDir, { recursive: true });
 
-      // Create a single project with all packages
       const projectPath = path.join(this.tempDir, 'project');
       await fs.mkdir(projectPath, { recursive: true });
 
@@ -101,14 +99,11 @@ export class MultipleNodeExtractor extends BaseExtractor<
     packagePath: string,
     projectPath: string
   ): Promise<CompleteNodeDescription[]> {
-    // Get declared nodes from package.json
     const declaredNodes = await getDeclaredNodes(packagePath);
     this.log(`[${packageName}] 🔍 Found ${JSON.stringify(declaredNodes)}`);
-    // Process nodes in parallel using Promise.all
     const nodePromises = declaredNodes.map(async nodePath => {
       this.log(`[${packageName}] 🔍 Processing: ${nodePath}`);
 
-      // Generate path variations
       const variations = [
         nodePath,
         nodePath.replace('.ts', '.js'),
@@ -116,7 +111,6 @@ export class MultipleNodeExtractor extends BaseExtractor<
         nodePath.replace('src/', 'lib/'),
       ];
 
-      // Check all variations in parallel
       const checkResults = await Promise.all(
         variations.map(async variation => {
           const fullPath = path.resolve(packagePath, variation);
@@ -130,7 +124,6 @@ export class MultipleNodeExtractor extends BaseExtractor<
         })
       );
 
-      // Find the first valid path
       const validPath = checkResults.find(result => result.exists);
       this.log(`[${packageName}] 🔍 Valid path: ${validPath?.path}`);
       if (validPath) {
@@ -150,7 +143,6 @@ export class MultipleNodeExtractor extends BaseExtractor<
       return null;
     });
 
-    // Filter out null results
     const nodes = (await Promise.all(nodePromises)).filter(
       node => node !== null
     ) as CompleteNodeDescription[];

--- a/src/extractors/multiple-node-extractor.ts
+++ b/src/extractors/multiple-node-extractor.ts
@@ -1,0 +1,211 @@
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import { execSync } from 'child_process';
+import { BaseExtractor } from './base-extractor';
+import { CompleteNodeDescription, ExtractorConfig } from '../types/node-description';
+import { getDeclaredNodes, parsePackageName } from '../utils/npm-utils';
+
+export class MultipleNodeExtractor extends BaseExtractor<
+  Record<string, CompleteNodeDescription[]>,
+  string[]
+> {
+  private packagePaths: Map<string, string> = new Map();
+
+  constructor(config?: ExtractorConfig) {
+    super(config);
+  }
+
+  /**
+   * Extract complete node descriptions from multiple community packages
+   */
+  protected async extractInternal(
+    config: string[]
+  ): Promise<Record<string, CompleteNodeDescription[]>> {
+    const packageNames = config;
+    console.log(
+      `📦 Extracting node descriptions from ${packageNames.length} packages: ${packageNames.join(', ')}`
+    );
+
+    try {
+      // Create temp directory
+      await fs.mkdir(this.tempDir, { recursive: true });
+
+      // Create a single project with all packages
+      const projectPath = path.join(this.tempDir, 'project');
+      await fs.mkdir(projectPath, { recursive: true });
+
+      // Create package.json with all dependencies
+      const packageJson: any = {
+        name: 'n8n-multi-extractor',
+        version: '1.0.0',
+        dependencies: {
+          'n8n-workflow': 'latest',
+          'n8n-core': 'latest',
+        },
+      };
+
+      // Add all packages as dependencies
+      for (const packageName of packageNames) {
+        const { name, version } = parsePackageName(packageName);
+        packageJson.dependencies[name] = version;
+      }
+
+      this.log('Project package.json: ' + JSON.stringify(packageJson, null, 2));
+
+      await fs.writeFile(
+        path.join(projectPath, 'package.json'),
+        JSON.stringify(packageJson, null, 2)
+      );
+
+      // Install all dependencies with a single npm install
+      console.log(`📦 Installing dependencies (this may take a while)...`);
+      execSync('npm install --no-save --silent --legacy-peer-deps', {
+        cwd: projectPath,
+        stdio: 'pipe',
+      });
+      console.log(`✅ Dependencies installed`);
+
+      // Process all packages in parallel
+      const results: Record<string, CompleteNodeDescription[]> = {};
+      const extractPromises = packageNames
+        .map(parsePackageName)
+        .map(async ({ name: packageName }) => {
+          const packagePath = path.join(projectPath, 'node_modules', packageName);
+          const nodes = await this.findNodes(packageName, packagePath, projectPath);
+          results[packageName] = nodes;
+          console.log(`✅ Extracted ${nodes.length} nodes from ${packageName}`);
+        });
+
+      await Promise.all(extractPromises);
+
+      this.extractedItems = results;
+      const totalNodes = Object.values(results).reduce((sum, nodes) => sum + nodes.length, 0);
+      console.log(
+        `✅ Found ${totalNodes} total node descriptions across ${packageNames.length} packages`
+      );
+
+      return results;
+    } catch (error) {
+      console.error(`❌ Extraction failed:`, error);
+      throw error;
+    } finally {
+      await this.cleanup();
+    }
+  }
+
+  /**
+   * Find nodes in a package
+   */
+  private async findNodes(
+    packageName: string,
+    packagePath: string,
+    projectPath: string
+  ): Promise<CompleteNodeDescription[]> {
+    // Get declared nodes from package.json
+    const declaredNodes = await getDeclaredNodes(packagePath);
+    this.log(`[${packageName}] 🔍 Found ${JSON.stringify(declaredNodes)}`);
+    // Process nodes in parallel using Promise.all
+    const nodePromises = declaredNodes.map(async nodePath => {
+      this.log(`[${packageName}] 🔍 Processing: ${nodePath}`);
+
+      // Generate path variations
+      const variations = [
+        nodePath,
+        nodePath.replace('.ts', '.js'),
+        nodePath.replace('src/', 'dist/'),
+        nodePath.replace('src/', 'lib/'),
+      ];
+
+      // Check all variations in parallel
+      const checkResults = await Promise.all(
+        variations.map(async variation => {
+          const fullPath = path.resolve(packagePath, variation);
+          this.log(`[${packageName}] 🔍 Checking: ${fullPath}`);
+          try {
+            await fs.access(fullPath);
+            return { exists: true, path: fullPath };
+          } catch {
+            return { exists: false, path: fullPath };
+          }
+        })
+      );
+
+      // Find the first valid path
+      const validPath = checkResults.find(result => result.exists);
+      this.log(`[${packageName}] 🔍 Valid path: ${validPath?.path}`);
+      if (validPath) {
+        const projectNodeModules = path.join(projectPath, 'node_modules');
+        const node = await this.extractCompleteNode(
+          validPath.path,
+          packageName,
+          packagePath,
+          projectNodeModules
+        );
+        if (node) {
+          return node;
+        }
+      }
+
+      console.warn(`❌ Could not extract: ${nodePath} from ${packageName}`);
+      return null;
+    });
+
+    // Filter out null results
+    const nodes = (await Promise.all(nodePromises)).filter(
+      node => node !== null
+    ) as CompleteNodeDescription[];
+
+    return nodes;
+  }
+
+  /**
+   * Print summary of extracted nodes
+   */
+  printSummary(): void {
+    if (Object.keys(this.extractedItems).length === 0) {
+      console.log('\n❌ No nodes found');
+      return;
+    }
+
+    console.log('\n📊 Node Descriptions Extracted:');
+    let index = 1;
+    for (const [packageName, nodes] of Object.entries(this.extractedItems)) {
+      console.log(`\n📦 Package: ${packageName} (${nodes.length} nodes)`);
+      nodes.forEach(node => {
+        console.log(`  ${index}. ${node.displayName} (${node.name})`);
+        console.log(`     Description: ${node.description}`);
+        console.log(`     Groups: ${node.group.join(', ')}`);
+        console.log(`     Version: ${node.version}`);
+        console.log(`     Properties: ${node.properties.length}`);
+        console.log(`     Credentials: ${node.credentials?.length || 0}`);
+        console.log(`     Webhooks: ${node.webhooks ? 'Yes' : 'No'}`);
+        console.log(`     Load Options: ${node.__loadOptionsMethods?.length || 0}`);
+
+        if (node.icon) {
+          console.log(`     Icon: ${node.icon}`);
+        }
+        if (node.iconUrl) {
+          console.log(`     Icon URL: ${node.iconUrl}`);
+        }
+        index++;
+      });
+    }
+  }
+
+  /**
+   * Save results with metadata in key-value format
+   */
+  async saveResults(filename: string): Promise<void> {
+    const data = {
+      extractedAt: new Date().toISOString(),
+      totalPackages: Object.keys(this.extractedItems).length,
+      totalNodes: Object.values(this.extractedItems).reduce((sum, nodes) => sum + nodes.length, 0),
+      format: 'node-descriptions',
+      packages: this.extractedItems,
+    };
+
+    const filePath = path.join(this.outputDir, filename);
+    await fs.writeFile(filePath, JSON.stringify(data, null, 2));
+    console.log(`💾 Saved descriptions to ${filePath}`);
+  }
+}

--- a/src/extractors/node-extractor.ts
+++ b/src/extractors/node-extractor.ts
@@ -3,23 +3,9 @@ import * as path from 'path';
 import { BaseExtractor } from './base-extractor';
 import { CompleteNodeDescription, ExtractorConfig } from '../types/node-description';
 import { downloadAndExtractPackage } from '../utils/download-utils';
-import { getDeclaredNodes, setupN8nDependencies } from '../utils/npm-utils';
+import { getDeclaredNodes, parsePackageName, setupN8nDependencies } from '../utils/npm-utils';
 
-// Type definitions for better type safety
-interface NodeModule {
-  default?: any;
-  [key: string]: any;
-}
-
-interface NodeInstance {
-  description: Partial<CompleteNodeDescription>;
-  methods?: {
-    loadOptions?: Record<string, Function>;
-    [key: string]: any;
-  };
-}
-
-export class NodeExtractor extends BaseExtractor<CompleteNodeDescription> {
+export class NodeExtractor extends BaseExtractor<CompleteNodeDescription[], string> {
   private packagePath: string = '';
 
   constructor(config?: ExtractorConfig) {
@@ -29,7 +15,8 @@ export class NodeExtractor extends BaseExtractor<CompleteNodeDescription> {
   /**
    * Extract complete node descriptions from a community package
    */
-  async extractInternal(packageName: string): Promise<CompleteNodeDescription[]> {
+  async extractInternal(config: string): Promise<CompleteNodeDescription[]> {
+    const { name: packageName, version } = parsePackageName(config);
     console.log(`📦 Extracting node descriptions from: ${packageName}`);
 
     try {
@@ -37,7 +24,7 @@ export class NodeExtractor extends BaseExtractor<CompleteNodeDescription> {
       await fs.mkdir(this.tempDir, { recursive: true });
 
       // Download and extract package
-      this.packagePath = await downloadAndExtractPackage(packageName, this.tempDir);
+      this.packagePath = await downloadAndExtractPackage(packageName, this.tempDir, version);
 
       // Setup n8n dependencies
       await setupN8nDependencies(this.packagePath);
@@ -93,7 +80,13 @@ export class NodeExtractor extends BaseExtractor<CompleteNodeDescription> {
       const validPath = checkResults.find(result => result.exists);
 
       if (validPath) {
-        const node = await this.extractCompleteNode(validPath.path, packageName);
+        const packageNodeModules = path.join(this.packagePath, 'node_modules');
+        const node = await this.extractCompleteNode(
+          validPath.path,
+          packageName,
+          this.packagePath,
+          packageNodeModules
+        );
         if (node) {
           return node;
         }
@@ -109,101 +102,6 @@ export class NodeExtractor extends BaseExtractor<CompleteNodeDescription> {
     ) as CompleteNodeDescription[];
 
     return nodes;
-  }
-
-  /**
-   * Extract complete node description
-   */
-  private async extractCompleteNode(
-    filePath: string,
-    packageName: string
-  ): Promise<CompleteNodeDescription | null> {
-    try {
-      this.log(`🔧 Extracting description from: ${path.basename(filePath)}`);
-
-      // Setup module resolution
-      const packageNodeModules = path.join(this.packagePath, 'node_modules');
-      const originalPaths = module.paths.slice();
-
-      if (!module.paths.includes(packageNodeModules)) {
-        module.paths.unshift(packageNodeModules);
-      }
-
-      try {
-        // Load the module with timeout safety
-        const nodeModule = await this.loadNodeModule(filePath);
-
-        // Use the extracted method to get the node class
-        const NodeClass = this.resolveNodeClass(nodeModule);
-
-        if (!NodeClass || typeof NodeClass !== 'function') {
-          this.log(`❌ No valid NodeClass found in ${path.basename(filePath)}`);
-          return null;
-        }
-
-        // Create instance and get description
-        const nodeInstance = new NodeClass();
-        const description = nodeInstance.description;
-
-        if (!description || !description.name) {
-          this.log(`❌ No valid description in ${path.basename(filePath)}`);
-          return null;
-        }
-
-        console.log(`✅ Extracted description for: ${description.displayName}`);
-
-        // Return the COMPLETE description object
-        const completeDescription: CompleteNodeDescription = {
-          ...description,
-          displayName: description.displayName,
-          name: this.generateNodeName(description.name, packageName),
-          group: description.group || [],
-          version: description.version,
-          description: description.description || '',
-          defaults: description.defaults || {},
-          inputs: description.inputs || ['main'],
-          outputs: description.outputs || ['main'],
-          properties: description.properties || [],
-        };
-
-        // Add load options methods if available
-        if (nodeInstance.methods?.loadOptions) {
-          completeDescription.__loadOptionsMethods = Object.keys(nodeInstance.methods.loadOptions);
-        }
-
-        // Process icons using the extracted method
-        const iconInfo = this.processNodeIcons(description, packageName, filePath);
-
-        if (iconInfo.icon) {
-          completeDescription.icon = iconInfo.icon;
-          // If we're using a Font Awesome icon, remove any iconUrl
-          if (iconInfo.icon.startsWith('fa:')) {
-            delete completeDescription.iconUrl;
-          }
-        }
-        
-        if (iconInfo.iconUrl) {
-          completeDescription.iconUrl = iconInfo.iconUrl;
-        }
-        
-        if (iconInfo.iconLightUrl) {
-          completeDescription.iconUrl = iconInfo.iconLightUrl;
-        }
-        if (iconInfo.iconDarkUrl) {
-          completeDescription.iconUrl = iconInfo.iconDarkUrl;
-        }
-
-        return completeDescription;
-      } finally {
-        // Restore paths
-        module.paths.splice(0, module.paths.length, ...originalPaths);
-      }
-    } catch (error) {
-      this.log(
-        `❌ Extraction error for ${path.basename(filePath)}: ${error instanceof Error ? error.message : String(error)}`
-      );
-      return null;
-    }
   }
 
   /**
@@ -231,119 +129,6 @@ export class NodeExtractor extends BaseExtractor<CompleteNodeDescription> {
       }
       if (node.iconUrl) {
         console.log(`   Icon URL: ${node.iconUrl}`);
-      }
-    });
-  }
-
-  private resolveNodeClass(nodeModule: any): any {
-    if (nodeModule.default && typeof nodeModule.default === 'function') {
-      return nodeModule.default;
-    }
-
-    // Try any function export
-    for (const [key, value] of Object.entries(nodeModule)) {
-      if (typeof value === 'function' && key !== 'default') {
-        return value;
-      }
-    }
-
-    return null;
-  }
-
-  private processNodeIcons(
-    description: any,
-    packageName: string,
-    filePath: string
-  ): { icon?: string; iconUrl?: string; iconLightUrl?: string; iconDarkUrl?: string } {
-    const result: { icon?: string; iconUrl?: string; iconLightUrl?: string; iconDarkUrl?: string } = {};
-  
-    if (description.icon) {
-      if (typeof description.icon === 'string') {
-        if (description.icon.startsWith('fa:')) {
-          result.icon = description.icon;
-        } else {
-          const iconPath = description.icon.startsWith('file:')
-            ? description.icon.replace('file:', '')
-            : description.icon;
-          result.iconUrl = this.generateIconUrl(iconPath, packageName, filePath);
-        }
-      } else if (typeof description.icon === 'object' && (description.icon.light || description.icon.dark)) {
-        if (description.icon.light) {
-          const iconLightPath = description.icon.light.startsWith('file:')
-            ? description.icon.light.replace('file:', '')
-            : description.icon.light;
-          result.iconLightUrl = this.generateIconUrl(iconLightPath, packageName, filePath);
-        }
-        if (description.icon.dark) {
-          const iconDarkPath = description.icon.dark.startsWith('file:')
-            ? description.icon.dark.replace('file:', '')
-            : description.icon.dark;
-          result.iconDarkUrl = this.generateIconUrl(iconDarkPath, packageName, filePath);
-          // If both light and dark are present, prefer dark for iconUrl
-          result.iconUrl = result.iconDarkUrl;
-        } else if (result.iconLightUrl) {
-          // If only light is present, use it for iconUrl
-          result.iconUrl = result.iconLightUrl;
-        }
-      }
-    }
-  
-    if (description.iconUrl) {
-      result.iconUrl = this.generateIconUrl(description.iconUrl, packageName, filePath);
-    }
-  
-    return result;
-  }
-
-  private generateNodeName(originalName: string, packageName: string): string {
-    const cleanPackageName = packageName.replace(/^@[^/]+\//, '').replace(/^n8n-nodes-/, '');
-    return `n8n-nodes-${cleanPackageName}.${originalName}`;
-  }
-
-  private generateIconUrl(iconPath: string, packageName: string, nodePath: string): string {
-    const cleanPackageName = packageName.replace(/^@[^/]+\//, '');
-    const nodeDir = path.dirname(nodePath);
-  
-    // Remove any leading "file:" prefix
-    let normalizedIconPath = iconPath.startsWith('file:') ? iconPath.replace(/^file:/, '') : iconPath;
-  
-    // Resolve path based on different patterns
-    let resolvedPath = normalizedIconPath;
-  
-    if (normalizedIconPath.startsWith('/')) {
-      // Absolute path within package
-      resolvedPath = normalizedIconPath.substring(1);
-    } else if (
-      !normalizedIconPath.includes('/') ||
-      normalizedIconPath.startsWith('./') ||
-      normalizedIconPath.startsWith('../')
-    ) {
-      // Relative path or just filename
-      const absolutePath = path.resolve(nodeDir, normalizedIconPath);
-      resolvedPath = path.relative(this.packagePath, absolutePath).replace(/\\/g, '/');
-    }
-  
-    return `icons/${cleanPackageName}/${resolvedPath}`;
-  }
-
-  /**
-   * Safely load a node module with timeout
-   */
-  private async loadNodeModule(filePath: string, timeoutMs: number = 10000): Promise<NodeModule> {
-    return new Promise((resolve, reject) => {
-      const timeoutId = setTimeout(() => {
-        reject(new Error(`Module load timeout: ${filePath}`));
-      }, timeoutMs);
-
-      try {
-        const resolvedPath = require.resolve(filePath);
-        delete require.cache[resolvedPath];
-        const module = require(filePath);
-        clearTimeout(timeoutId);
-        resolve(module);
-      } catch (error) {
-        clearTimeout(timeoutId);
-        reject(error);
       }
     });
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export { NodeExtractor } from './extractors/node-extractor';
+export { MultipleNodeExtractor } from './extractors/multiple-node-extractor';
 export { CompleteNodeDescription } from './types/node-description';
 export { main } from './cli';
 

--- a/src/utils/download-utils.ts
+++ b/src/utils/download-utils.ts
@@ -26,9 +26,9 @@ export async function downloadFile(url: string, destination: string): Promise<vo
 /**
  * Get package info from npm registry
  */
-export async function getPackageInfo(packageName: string): Promise<PackageInfo> {
+export async function getPackageInfo(packageName: string, version?: string): Promise<PackageInfo> {
   const response = await fetch(
-    `https://registry.npmjs.org/${encodeURIComponent(packageName)}/latest`
+    `https://registry.npmjs.org/${encodeURIComponent(packageName)}/${version || 'latest'}`
   );
   if (!response.ok) {
     throw new Error(`Package not found: ${packageName} (${response.status})`);
@@ -41,9 +41,10 @@ export async function getPackageInfo(packageName: string): Promise<PackageInfo> 
  */
 export async function downloadAndExtractPackage(
   packageName: string,
-  tempDir: string
+  tempDir: string,
+  version?: string
 ): Promise<string> {
-  const packageInfo = await getPackageInfo(packageName);
+  const packageInfo = await getPackageInfo(packageName, version);
   console.log(`📋 Package version: ${packageInfo.version}`);
 
   const downloadPath = path.join(tempDir, 'package.tgz');

--- a/src/utils/npm-utils.ts
+++ b/src/utils/npm-utils.ts
@@ -43,7 +43,6 @@ export async function setupN8nDependencies(packagePath: string): Promise<void> {
 export async function getDeclaredNodes(packagePath: string): Promise<string[]> {
   try {
     const packageJsonPath = path.join(packagePath, 'package.json');
-    console.log(`[${packagePath}] 🔍 Reading package.json: ${packageJsonPath}`);
     const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf8'));
 
     if (packageJson.n8n?.nodes) {

--- a/src/utils/npm-utils.ts
+++ b/src/utils/npm-utils.ts
@@ -43,6 +43,7 @@ export async function setupN8nDependencies(packagePath: string): Promise<void> {
 export async function getDeclaredNodes(packagePath: string): Promise<string[]> {
   try {
     const packageJsonPath = path.join(packagePath, 'package.json');
+    console.log(`[${packagePath}] 🔍 Reading package.json: ${packageJsonPath}`);
     const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf8'));
 
     if (packageJson.n8n?.nodes) {
@@ -53,4 +54,13 @@ export async function getDeclaredNodes(packagePath: string): Promise<string[]> {
   } catch {
     return [];
   }
+}
+
+export function parsePackageName(packageName: string): { name: string; version: string } {
+  const match = packageName.match(/(@?.+)@(.+)/);
+  if (match) {
+    const [, name, version] = match;
+    return { name, version };
+  }
+  return { name: packageName, version: 'latest' };
 }


### PR DESCRIPTION
This PR allows supplying multiple package names to be processed in a single request. The script installs all packages in a single project and then processes them.
Other changes:
- refactored node extractor to reuse some methods in multiple node extractor
- supplied package version in arguments is used instead of the latest package version