### PR TITLE
feat: Extract aiNodeSdkVersion from community node packages

### DIFF
--- a/src/extractors/multiple-node-extractor.ts
+++ b/src/extractors/multiple-node-extractor.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import { execSync } from 'child_process';
 import { BaseExtractor } from './base-extractor';
 import { CompleteNodeDescription, ExtractorConfig } from '../types/node-description';
-import { getAiNodeSdkVersion, getDeclaredNodes, parsePackageName } from '../utils/npm-utils';
+import { getN8nPackageConfig, parsePackageName } from '../utils/npm-utils';
 
 export class MultipleNodeExtractor extends BaseExtractor<
   Record<string, CompleteNodeDescription[]>,
@@ -99,8 +99,7 @@ export class MultipleNodeExtractor extends BaseExtractor<
     packagePath: string,
     projectPath: string
   ): Promise<CompleteNodeDescription[]> {
-    const declaredNodes = await getDeclaredNodes(packagePath);
-    const aiNodeSdkVersion = await getAiNodeSdkVersion(packagePath);
+    const { nodes: declaredNodes, aiNodeSdkVersion } = await getN8nPackageConfig(packagePath);
     this.log(`[${packageName}] 🔍 Found ${JSON.stringify(declaredNodes)}`);
     const nodePromises = declaredNodes.map(async nodePath => {
       this.log(`[${packageName}] 🔍 Processing: ${nodePath}`);

--- a/src/extractors/multiple-node-extractor.ts
+++ b/src/extractors/multiple-node-extractor.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import { execSync } from 'child_process';
 import { BaseExtractor } from './base-extractor';
 import { CompleteNodeDescription, ExtractorConfig } from '../types/node-description';
-import { getDeclaredNodes, parsePackageName } from '../utils/npm-utils';
+import { getAiNodeSdkVersion, getDeclaredNodes, parsePackageName } from '../utils/npm-utils';
 
 export class MultipleNodeExtractor extends BaseExtractor<
   Record<string, CompleteNodeDescription[]>,
@@ -100,6 +100,7 @@ export class MultipleNodeExtractor extends BaseExtractor<
     projectPath: string
   ): Promise<CompleteNodeDescription[]> {
     const declaredNodes = await getDeclaredNodes(packagePath);
+    const aiNodeSdkVersion = await getAiNodeSdkVersion(packagePath);
     this.log(`[${packageName}] 🔍 Found ${JSON.stringify(declaredNodes)}`);
     const nodePromises = declaredNodes.map(async nodePath => {
       this.log(`[${packageName}] 🔍 Processing: ${nodePath}`);
@@ -135,6 +136,9 @@ export class MultipleNodeExtractor extends BaseExtractor<
           projectNodeModules
         );
         if (node) {
+          if (aiNodeSdkVersion !== undefined) {
+            node.aiNodeSdkVersion = aiNodeSdkVersion;
+          }
           return node;
         }
       }

--- a/src/extractors/node-extractor.ts
+++ b/src/extractors/node-extractor.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import { BaseExtractor } from './base-extractor';
 import { CompleteNodeDescription, ExtractorConfig } from '../types/node-description';
 import { downloadAndExtractPackage } from '../utils/download-utils';
-import { getAiNodeSdkVersion, getDeclaredNodes, parsePackageName, setupN8nDependencies } from '../utils/npm-utils';
+import { getN8nPackageConfig, parsePackageName, setupN8nDependencies } from '../utils/npm-utils';
 
 export class NodeExtractor extends BaseExtractor<CompleteNodeDescription[], string> {
   private packagePath: string = '';
@@ -48,8 +48,7 @@ export class NodeExtractor extends BaseExtractor<CompleteNodeDescription[], stri
    * Find nodes in the package
    */
   private async findNodes(packageName: string): Promise<CompleteNodeDescription[]> {
-    const declaredNodes = await getDeclaredNodes(this.packagePath);
-    const aiNodeSdkVersion = await getAiNodeSdkVersion(this.packagePath);
+    const { nodes: declaredNodes, aiNodeSdkVersion } = await getN8nPackageConfig(this.packagePath);
 
     // Process nodes in parallel using Promise.all
     const nodePromises = declaredNodes.map(async nodePath => {

--- a/src/extractors/node-extractor.ts
+++ b/src/extractors/node-extractor.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import { BaseExtractor } from './base-extractor';
 import { CompleteNodeDescription, ExtractorConfig } from '../types/node-description';
 import { downloadAndExtractPackage } from '../utils/download-utils';
-import { getDeclaredNodes, parsePackageName, setupN8nDependencies } from '../utils/npm-utils';
+import { getAiNodeSdkVersion, getDeclaredNodes, parsePackageName, setupN8nDependencies } from '../utils/npm-utils';
 
 export class NodeExtractor extends BaseExtractor<CompleteNodeDescription[], string> {
   private packagePath: string = '';
@@ -48,8 +48,9 @@ export class NodeExtractor extends BaseExtractor<CompleteNodeDescription[], stri
    * Find nodes in the package
    */
   private async findNodes(packageName: string): Promise<CompleteNodeDescription[]> {
-    // Get declared nodes from package.json
+    // Get declared nodes and optional aiNodeSdkVersion from package.json
     const declaredNodes = await getDeclaredNodes(this.packagePath);
+    const aiNodeSdkVersion = await getAiNodeSdkVersion(this.packagePath);
 
     // Process nodes in parallel using Promise.all
     const nodePromises = declaredNodes.map(async nodePath => {
@@ -88,6 +89,9 @@ export class NodeExtractor extends BaseExtractor<CompleteNodeDescription[], stri
           packageNodeModules
         );
         if (node) {
+          if (aiNodeSdkVersion !== undefined) {
+            node.aiNodeSdkVersion = aiNodeSdkVersion;
+          }
           return node;
         }
       }

--- a/src/extractors/node-extractor.ts
+++ b/src/extractors/node-extractor.ts
@@ -48,7 +48,6 @@ export class NodeExtractor extends BaseExtractor<CompleteNodeDescription[], stri
    * Find nodes in the package
    */
   private async findNodes(packageName: string): Promise<CompleteNodeDescription[]> {
-    // Get declared nodes and optional aiNodeSdkVersion from package.json
     const declaredNodes = await getDeclaredNodes(this.packagePath);
     const aiNodeSdkVersion = await getAiNodeSdkVersion(this.packagePath);
 

--- a/src/types/node-description.ts
+++ b/src/types/node-description.ts
@@ -47,6 +47,7 @@ export interface CompleteNodeDescription {
   }>;
   polling?: boolean;
   subtitle?: string;
+  aiNodeSdkVersion?: number;
   __loadOptionsMethods?: string[];
   codex?: {
     categories?: string[];

--- a/src/utils/npm-utils.ts
+++ b/src/utils/npm-utils.ts
@@ -86,7 +86,12 @@ export async function getAiNodeSdkVersion(packagePath: string): Promise<number |
     const packageJsonPath = path.join(packagePath, 'package.json');
     const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf8'));
 
-    return packageJson.n8n?.aiNodeSdkVersion;
+    const version = packageJson.n8n?.aiNodeSdkVersion;
+    if (typeof version === 'number' && Number.isInteger(version) && version > 0) {
+      return version;
+    }
+
+    return undefined;
   } catch {
     return undefined;
   }

--- a/src/utils/npm-utils.ts
+++ b/src/utils/npm-utils.ts
@@ -78,6 +78,20 @@ export async function getDeclaredNodes(packagePath: string): Promise<string[]> {
   }
 }
 
+/**
+ * Get optional aiNodeSdkVersion from package.json n8n config
+ */
+export async function getAiNodeSdkVersion(packagePath: string): Promise<number | undefined> {
+  try {
+    const packageJsonPath = path.join(packagePath, 'package.json');
+    const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf8'));
+
+    return packageJson.n8n?.aiNodeSdkVersion;
+  } catch {
+    return undefined;
+  }
+}
+
 export function parsePackageName(packageName: string): { name: string; version: string } {
   const match = packageName.match(/(@?.+)@(.+)/);
   if (match) {

--- a/src/utils/npm-utils.ts
+++ b/src/utils/npm-utils.ts
@@ -60,40 +60,32 @@ export async function setupN8nDependencies(packagePath: string): Promise<void> {
   }
 }
 
-/**
- * Get declared nodes from package.json
- */
-export async function getDeclaredNodes(packagePath: string): Promise<string[]> {
-  try {
-    const packageJsonPath = path.join(packagePath, 'package.json');
-    const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf8'));
-
-    if (packageJson.n8n?.nodes) {
-      return packageJson.n8n.nodes;
-    }
-
-    return [];
-  } catch {
-    return [];
-  }
+export interface N8nPackageConfig {
+  nodes: string[];
+  aiNodeSdkVersion?: number;
 }
 
 /**
- * Get optional aiNodeSdkVersion from package.json n8n config
+ * Get n8n config from package.json (declared nodes and optional aiNodeSdkVersion)
  */
-export async function getAiNodeSdkVersion(packagePath: string): Promise<number | undefined> {
+export async function getN8nPackageConfig(packagePath: string): Promise<N8nPackageConfig> {
   try {
     const packageJsonPath = path.join(packagePath, 'package.json');
     const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf8'));
+    const n8n = packageJson.n8n;
 
-    const version = packageJson.n8n?.aiNodeSdkVersion;
+    const config: N8nPackageConfig = {
+      nodes: n8n?.nodes ?? [],
+    };
+
+    const version = n8n?.aiNodeSdkVersion;
     if (typeof version === 'number' && Number.isInteger(version) && version > 0) {
-      return version;
+      config.aiNodeSdkVersion = version;
     }
 
-    return undefined;
+    return config;
   } catch {
-    return undefined;
+    return { nodes: [] };
   }
 }
 


### PR DESCRIPTION
Read `aiNodeSdkVersion` from the `n8n` section of the community node's `package.json` and include it in the output JSON so it can be forwarded to Strapi.

Each extracted node in the output includes `aiNodeSdkVersion` when present in the source package:
- **Single package output** — each node in `nodes[]` includes `aiNodeSdkVersion`.
- **Multiple package output** — each node within its package entry includes `aiNodeSdkVersion`.

### Expected `package.json` structure

```json
{
  "name": "n8n-nodes-my-ai-node",
  "n8n": {
    "aiNodeSdkVersion": 1,
    "nodes": ["dist/nodes/MyNode.node.js"]
  }
}
```

Aligns with the ESLint rule in [n8n-io/n8n#25759](https://github.com/n8n-io/n8n/pull/25759) which enforces `n8n.aiNodeSdkVersion`.